### PR TITLE
Fix App Store pre-submission text mismatches (#45)

### DIFF
--- a/docs/app-review-notes.md
+++ b/docs/app-review-notes.md
@@ -55,9 +55,9 @@ Location works in two modes:
 
 **Manual selection** — tapping the location name at the top of the screen opens the location selector. It shows:
 
+- Current location (if GPS permission is granted)
 - Recent locations (previously visited)
 - A list of pre-approved popular locations
-- A search field for free-text entry of any city
 
 The location indicator uses a colour coding system:
 
@@ -79,11 +79,10 @@ Reviewers can force a fresh network fetch by pulling down to refresh on any peri
 
 The share button (top right on each period screen) does the following:
 
-1. Captures the chart as an image with a description footer baked in
-2. Creates a share record on the TempHist API and returns a short URL
-3. Opens the iOS share sheet with the URL, allowing the user to share via Messages, Mail, or any other app
+1. Creates a share record on the TempHist API and returns a short URL
+2. Opens the iOS share sheet with that URL, allowing the user to share via Messages, Mail, or any other app
 
-Sharing requires an active network connection. The share URL resolves to a web page showing the same chart with Open Graph metadata for rich link previews.
+Sharing requires an active network connection. The URL resolves to a web page showing the same chart and includes Open Graph metadata so link previews in Messages, Mail, etc. render a title, description, and preview image.
 
 ---
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -27,9 +27,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>This app uses your location to show temperature data for where you are. Your location is shared with our weather data provider and is not stored permanently.</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>This app uses your location to show temperature data for where you are. Your location is shared with our weather data provider and is not stored permanently. This app does not use background location.</string>
+	<string>TempHist uses your location to show temperature data for where you are. The detected city is sent to our weather data provider and saved on this device so the app opens at your most recent location and keeps a short list of recent places for quick access.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Summary

Addresses [issue #45](https://github.com/turnpiece/temphist_app/issues/45) — App Store pre-submission checklist. Brings user- and reviewer-facing text in line with shipped behaviour before the next iOS submission.

- **`ios/Runner/Info.plist`** — rewrote `NSLocationWhenInUseUsageDescription` so it no longer claims location is *"not stored permanently"* (the app persists `gpsLocationPersisted` and up to 10 `locationHistory` entries in `SharedPreferences` with no expiry). Removed the unused `NSLocationAlwaysAndWhenInUseUsageDescription` key — the app only calls `geo.Geolocator.requestPermission()` (while-in-use) and does no background location. [P0-1 + P2]
- **`docs/app-review-notes.md`** — removed the stale "free-text city search" bullet; the location selector UI only shows Current / Recent / Popular lists. Rewrote the Sharing section to describe the actual URL-only share flow (`captureWidget()` in `share_service.dart` is defined but never invoked). [P1-1, P1-2]

Privacy-manifest and data-storage behaviour are unchanged: `PrivacyInfo.xcprivacy` already declares coarse location as linked with App Functionality purpose, which matches runtime behaviour.

## Out-of-repo follow-ups (not addressed by this PR)

Issue #45 also requires these, which live outside this repo:

- [ ] Re-check privacy policy at `https://temphist.com/privacy/app` against the new Info.plist wording — confirm it acknowledges on-device storage of the detected city and recent locations.
- [ ] Verify App Store Connect privacy questionnaire answers match `PrivacyInfo.xcprivacy` (Coarse Location, linked via anonymous Firebase UID, App Functionality, no tracking).

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 54/54 pass
- [x] `flutter build ios --release --no-codesign` — builds cleanly with the reduced permission key set
- [ ] Manual on device/simulator, first launch:
  - [ ] Deny location → prompt shows new WhenInUse copy; app falls back and prompts for manual selection
  - [ ] Grant location → GPS resolves; open location selector and confirm UI matches the updated notes (Current / Recent / Popular; no search field)
  - [ ] Settings → Privacy policy link opens `https://temphist.com/privacy/app`
  - [ ] Share from any period screen → iOS share sheet opens with a `https://temphist.com/s/<id>` URL (no image attachment)
- [ ] Walk through `docs/app-review-notes.md` end-to-end as a reviewer would — every step should be executable in the shipped app

🤖 Generated with [Claude Code](https://claude.com/claude-code)